### PR TITLE
More Fun: Relocate bot.js + Parentheses Support + Refactor

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 node_modules
+react-client
 .idea

--- a/README.md
+++ b/README.md
@@ -23,10 +23,11 @@ The MathAsker (Producer) sends a series of random arithmetic expressions to the 
 - `*` Multiplication
 - `/` Division
 - `^` Exponents
+- `(` and `)` Parentheses
 
 ## Installation/Requirements
 
-- Requires node.js v4.x (for ease of node version management I've found [nvm](https://github.com/creationix/nvm) to be :+1:)
+- :warning: **Requires node.js v4.x** (for node version management I've found [nvm](https://github.com/creationix/nvm) to be :+1:)
 
 ```
 git clone https://github.com/erikthedeveloper/nodejs-math-slinger.git
@@ -46,11 +47,11 @@ npm install
 
 - [x] :scissors: :fire: :scissors: code for POST /evaluate in favor of GET /math (simplicity)
 - [x] Refactor. Refactor. Refactor.
-- [ ] Support parenthesis in equations (i.e. `(2*(3+4)/4)-(2^2/(4*20)=`)
+- [x] Support parenthesis in equations (i.e. `(2*(3+4)/4)-(2^2/(4*20)=`)
 - [ ] Respond w/ JSON
 - [x] ESLint
-- [ ] Refactor. Refactor. Refactor.
-- [ ] Web Client w/ React (Calculator)
+- [x] Refactor. Refactor. Refactor.
+- [x] Web Client w/ React (Calculator) _90% complete%_
 - [ ] Node v0.12.x branch via Babel/Webpack
 - [ ] ES6+ branch via Babel/Webpack :)
 - [ ] Refactor. Refactor. Refactor.
@@ -61,8 +62,6 @@ npm install
 - `npm test` sets `NODE_ENV=test` and runs all tests.
 - `npm test -- --watch` runs tests and watches files for changes.
 - `npm run lint` will lint the project using [ESLint](http://eslint.org/) and the rules defined in `.eslintrc`.
-
-![image](https://cloud.githubusercontent.com/assets/1240178/10477586/8696f3e0-7214-11e5-9eec-30d5957e03ac.png)
 
 ```
   Math Evaluator Service [integration]
@@ -83,6 +82,8 @@ npm install
     #validateExpression
       ✓ should pass for a simple addition expression
       ✓ should pass for a simple subtraction expression
+      ✓ should pass for an expression containing parentheses
+      ✓ should fail for an expression containing unclosed/mismatched parentheses
       ✓ should enforce the ending "="
       ✓ should not allow any whitespace
     #evaluateExpression
@@ -90,6 +91,7 @@ npm install
       ✓ evaluates addition/substraction expressions
       ✓ evaluates multiplication/division expressions
       ✓ evaluates exponent expressions
+      ✓ evaluates expressions containing parentheses
 
   expressionGenerator
     #randomExpression
@@ -99,10 +101,11 @@ npm install
   Infix to Postfix Converter
     ✓ Should convert simple addition
     ✓ should convert all sorts of infix goodies to postfix...
+    ✓ should convert infix expressions containing parentheses to postfix...
     ✓ should reject expressions containing negative numbers
 
   Postfix Evaluator
-    ✓ does math
+    ✓ Evaluates postfix mathematical expressions
 ```
 
 ## UML Diagrams

--- a/lib/bots/math-bot.js
+++ b/lib/bots/math-bot.js
@@ -1,7 +1,7 @@
 'use strict';
 var http = require('http');
-var streams = require('./lib/util/streams');
-var log = require('./lib/util/log');
+var streams = require('./../util/streams');
+var log = require('./../util/log');
 
 var requestOptions = {
   host: 'localhost',

--- a/lib/math/expressionEvaluator.js
+++ b/lib/math/expressionEvaluator.js
@@ -6,9 +6,14 @@ var infixPostfix = require('./infixPostfix');
  *  Require trailing "="
  *  Allow operators: + - * / ^
  *  Cannot begin with a negative number
+ *  Valid use of parentheses
  */
 function validateExpression(expr) {
-  return /^[0-9+\-*/^]+\=$/.test(expr) && /^[^\-]/.test(expr);
+  return (
+    /^([0-9+\-*/^()])+\=$/.test(expr) &&
+    /^[^\-]/.test(expr) &&
+    validateClosingParentheses(expr)
+  )
 }
 
 function evaluateExpression(expr) {
@@ -19,6 +24,21 @@ function evaluateExpression(expr) {
   return infixPostfix.evaluatePostfix(
     infixPostfix.toPostfix(infix)
   );
+}
+
+/**
+ * Verify correct usage of parentheses opening/closing
+ * @param {string} expr
+ */
+function validateClosingParentheses(expr) {
+  var balance = 0;
+  for (let char of expr.split('')){
+    if (char === "(") balance++;
+    if (char === ')') balance--;
+    if (balance < 0) return false;
+  }
+
+  return balance === 0;
 }
 
 module.exports = {

--- a/lib/math/infixPostfix.js
+++ b/lib/math/infixPostfix.js
@@ -34,8 +34,13 @@ function toPostfix(infix) {
     .forEach(item => {
       if (operandRegex.test(item)) {
         addItem(item);
-      } else if (_stack.empty() || operatorVal(item) > operatorVal(_stack.top())) {
+      } else if (_stack.empty() || item === '(' || operatorVal(item) > operatorVal(_stack.top())) {
         _stack.push(item);
+      } else if (item === ')') {
+        while (_stack.top() !== '(') {
+          addItem(_stack.pop())
+        }
+        _stack.pop();
       } else {
         while (!_stack.empty() && operatorVal(item) <= operatorVal(_stack.top())) {
           addItem(_stack.pop());

--- a/spawn_bot.js
+++ b/spawn_bot.js
@@ -1,5 +1,5 @@
 'use strict';
-var bot = require('./bot');
+var bot = require('./lib/bots/math-bot');
 var randomExpression = require('./lib/math/expressionGenerator').randomExpression;
 
 startAsking(

--- a/test/unit/bot-test.js
+++ b/test/unit/bot-test.js
@@ -5,7 +5,7 @@ var sinon = require('sinon');
 var http = require('http');
 var PassThrough = require('stream').PassThrough;
 
-var bot = require('./../../bot');
+var bot = require('./../../lib/bots/math-bot');
 
 describe('MathBot - Requester of Mathematical Solutions', function() {
   var stubbedRequest;

--- a/test/unit/math/expressionEvaluator-test.js
+++ b/test/unit/math/expressionEvaluator-test.js
@@ -19,6 +19,21 @@ describe('expressionEvaluator', function () {
       ).to.be.true;
     });
 
+    it('should pass for an expression containing parentheses', function () {
+      expect(
+        validate('2*(12-10)=')
+      ).to.be.true;
+    });
+
+    it('should fail for an expression containing unclosed/mismatched parentheses', function () {
+      expect(
+        validate('2*(12-10=')
+      ).to.be.false;
+      expect(
+        validate('2+(4+4)+4)(=')
+      ).to.be.false;
+    });
+
     it('should enforce the ending "="', function () {
       expect(
         validate('2+3+13')

--- a/test/unit/math/expressionEvaluator-test.js
+++ b/test/unit/math/expressionEvaluator-test.js
@@ -1,113 +1,87 @@
 'use strict';
-var expect = require('chai').expect;
+var assert = require('chai').assert;
 var evaluator = require('./../../../lib/math/expressionEvaluator');
 
 describe('expressionEvaluator', function () {
 
 
   describe('#validateExpression', function () {
-    var validate = evaluator.validateExpression;
+    const assertValidate = (expected, expr) => {
+      assert.equal(expected, evaluator.validateExpression(expr));
+    };
     it('should pass for a simple addition expression', function () {
-      expect(
-        validate('2+3+13=')
-      ).to.be.true;
+      assertValidate(true, '2+3+13=');
     });
 
     it('should pass for a simple subtraction expression', function () {
-      expect(
-        validate('2+3-13=')
-      ).to.be.true;
+      assertValidate(true, '2+3-13=');
     });
 
     it('should pass for an expression containing parentheses', function () {
-      expect(
-        validate('2*(12-10)=')
-      ).to.be.true;
+      assertValidate(true, '2*(12-10)=');
     });
 
     it('should fail for an expression containing unclosed/mismatched parentheses', function () {
-      expect(
-        validate('2*(12-10=')
-      ).to.be.false;
-      expect(
-        validate('2+(4+4)+4)(=')
-      ).to.be.false;
+      assertValidate(false, '2*(12-10=');
+      assertValidate(false, '2+(4+4)+4)(=');
     });
 
     it('should enforce the ending "="', function () {
-      expect(
-        validate('2+3+13')
-      ).to.be.false;
+      assertValidate(false, '2+3+13');
     });
 
     it('should not allow any whitespace', function () {
-      expect(
-        validate('2 + 3 + 13=')
-      ).to.be.false;
+      assertValidate(false, '2 + 3 + 13=');
     });
   });
 
   describe('#evaluateExpression', function () {
-    var evaluate = evaluator.evaluateExpression;
+    const assertSolutions = pairs => pairs.forEach(pair =>
+      assert.equal(
+        pair[1],
+        evaluator.evaluateExpression(pair[0]),
+        'Expression: ' + pair[0]
+      )
+    );
 
     it('evaluates simple addition expressions', function () {
-      [
+      assertSolutions([
         ['0=', 0],
         ['1+0=', 1],
         ['2+3=', 5],
         ['1+3=', 4],
         ['10+20+5=', 35],
-      ].forEach(pair =>
-        expect(
-          evaluate(pair[0])
-        ).to.equal(pair[1])
-      );
+      ])
     });
 
     it('evaluates addition/substraction expressions', function () {
-      [
+      assertSolutions([
         ['2+3-1=', 4],
         ['1+3-2=', 2],
         ['20-10+5=', 15],
-      ].forEach(pair =>
-        expect(
-          evaluate(pair[0])
-        ).to.equal(pair[1], 'For: ' + pair[0])
-      );
+      ]);
     });
 
     it('evaluates multiplication/division expressions', function () {
-      [
+      assertSolutions([
         ['2*2=', 4],
         ['2*3*4=', 24],
         ['2*10/5=', 4],
-      ].forEach(pair =>
-        expect(
-          evaluate(pair[0])
-        ).to.equal(pair[1], 'For: ' + pair[0])
-      );
+      ]);
     });
 
     it('evaluates exponent expressions', function () {
-      [
+      assertSolutions([
         ['2^10=', 1024],
         ['2+4^4=', 258]
-      ].forEach(pair =>
-        expect(
-          evaluate(pair[0])
-        ).to.equal(pair[1], 'For: ' + pair[0])
-      );
+      ]);
     });
 
     it('evaluates expressions containing parentheses', function () {
-      [
+      assertSolutions([
         ['10*(5-3)=', 20],
         ['100/(2*(10/5))=', 25]
-      ].forEach(pair =>
-        expect(
-          evaluate(pair[0])
-        ).to.equal(pair[1], 'For: ' + pair[0])
-      );
+      ]);
     });
 
   });

--- a/test/unit/math/expressionEvaluator-test.js
+++ b/test/unit/math/expressionEvaluator-test.js
@@ -99,5 +99,16 @@ describe('expressionEvaluator', function () {
       );
     });
 
+    it('evaluates expressions containing parentheses', function () {
+      [
+        ['10*(5-3)=', 20],
+        ['100/(2*(10/5))=', 25]
+      ].forEach(pair =>
+        expect(
+          evaluate(pair[0])
+        ).to.equal(pair[1], 'For: ' + pair[0])
+      );
+    });
+
   });
 });

--- a/test/unit/math/expressionGenerator-test.js
+++ b/test/unit/math/expressionGenerator-test.js
@@ -1,27 +1,19 @@
 'use strict';
-var expect = require('chai').expect;
+var assert = require('chai').assert;
 
-describe('expressionGenerator', function () {
+describe('expressionGenerator', function() {
 
-  var generator = require('./../../../lib/math/expressionGenerator');
+  var randomExpression = require('./../../../lib/math/expressionGenerator').randomExpression;
 
-  describe('#randomExpression', function () {
-    it('should generate a random, simple addition expression', function () {
-      expect(
-        generator.randomExpression()
-      ).to.match(/^[0-9+\-*/^]+\=$/);
+  describe('#randomExpression', function() {
+    it('should generate a random, simple addition expression', function() {
+      assert.match(randomExpression(), /^[0-9+\-*/^]+\=$/);
     });
 
-    it('should allow specifying count of numbers involved (length)', function () {
-      expect(
-        generator.randomExpression(3)
-      ).to.match(/^([0-9]+[+\-*/^]?){3}\=$/);
-      expect(
-        generator.randomExpression(6)
-      ).to.match(/^([0-9]+[+\-*/^]?){6}\=$/);
-      expect(
-        generator.randomExpression(1)
-      ).to.match(/^([0-9]+[+\-*/^]?){1}\=$/);
+    it('should allow specifying count of numbers involved (length)', function() {
+      assert.match(randomExpression(3), /^([0-9]+[+\-*/^]?){3}\=$/);
+      assert.match(randomExpression(6), /^([0-9]+[+\-*/^]?){6}\=$/);
+      assert.match(randomExpression(1), /^([0-9]+[+\-*/^]?){1}\=$/);
     });
   });
 });

--- a/test/unit/math/infixPostfix-test.js
+++ b/test/unit/math/infixPostfix-test.js
@@ -16,6 +16,11 @@ describe('Infix to Postfix Converter', function () {
     assert.equal(infixPostfix.toPostfix('1*2^3+4'), '1 2 3 ^ * 4 +');
   });
 
+  it('should convert infix expressions containing parentheses to postfix...', function() {
+    assert.equal(infixPostfix.toPostfix('1*(2+3)'), '1 2 3 + *');
+    assert.equal(infixPostfix.toPostfix('7-x*(3*x)/4'), '7 x 3 x * * 4 / -');
+  });
+
   it('should reject expressions containing negative numbers', function() {
     assert.throws(infixPostfix.toPostfix.bind(null, '-3+4'));
   });
@@ -23,7 +28,8 @@ describe('Infix to Postfix Converter', function () {
 });
 
 describe('Postfix Evaluator', function () {
-  it('does math', function() {
+  it('Evaluates postfix mathematical expressions', function() {
+    assert.equal(infixPostfix.evaluatePostfix('3 1 -'), 2);
     assert.equal(infixPostfix.evaluatePostfix('3 4 5 * +'), 23);
     assert.equal(infixPostfix.evaluatePostfix('8 4 2 / -'), 6);
     assert.equal(infixPostfix.evaluatePostfix('1 2 3 ^ * 4 +'), 12);


### PR DESCRIPTION
## Misc. Improvements, Fun, and House Cleaning
- [x] Moves/Renames /bot.js to lib/bots/math-bot.js
- [x] Refactors expression{Evaluator,Generator} tests - helpers + assert
- [x] infixToPostfix now handles parentheses
- [x] Expression validator now accepts parentheses and validates open/close
- [x] README - Adds parentheses support, Updates TODOs, and :warning: for node 4.1 requirement
